### PR TITLE
Diagnose appliance lookup failures instead of opaque timeouts (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.30.0] [2026-06-27]
+### improved appliance lookup diagnostics: room / appliance names are now matched via a unit-tested lib/locator helper that, on mismatch, reports the available names; the node warns when a matched appliance is not fully registered (stale appliances cause command timeouts); location name is trimmed - [#25](https://github.com/windkh/node-red-contrib-grohe-sense/issues/25)
+
 ## [0.29.0] [2026-06-27]
 ### adapted to the changed Sense Guard api: surfaced details.data_latest withdrawal + consumption summary as msg.payload.withdrawal / msg.payload.consumption, fixed convertWithdrawals to read the renamed max_flowrate field, updated the senseguardvalues example to use the live measurement, and added a fixture-backed test - [#26](https://github.com/windkh/node-red-contrib-grohe-sense/issues/26)
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ On startup the node logs in, retrieves the dashboard, and caches the rooms and a
 ## `grohe sense`
 The node is able to get the status of a Grohe Sense, Grohe Sense Plus or Grohe Sense Guard appliance. It is also used to send commands to a Sense Guard.
 
+> **Note on names:** the *Room* and *Name* (appliance) must match the values shown in the Grohe Ondus app **exactly**, including spaces and capitalization. If they don't match, the node logs the available room / appliance names to help you correct them. If commands such as *open/close valve* time out while reading still works, the configured name is likely resolving to a stale appliance that is no longer fully registered — rename it in the app and re-select it here. (see [#25](https://github.com/windkh/node-red-contrib-grohe-sense/issues/25))
+
 ### Inputs
 Any incoming message triggers a poll. The optional fields on `msg.payload` control what happens:
 

--- a/grohe/99-grohe.html
+++ b/grohe/99-grohe.html
@@ -123,9 +123,9 @@
         <dt>Location <span class="property-type">grohe location</span></dt>
         <dd>The configuration node that holds the credentials and identifies the location.</dd>
         <dt>Room <span class="property-type">string</span></dt>
-        <dd>Name of the room the appliance lives in (as shown in the Grohe Ondus app).</dd>
+        <dd>Name of the room the appliance lives in, matched <b>exactly</b> as shown in the Grohe Ondus app (including spaces and capitalization).</dd>
         <dt>Name <span class="property-type">string</span></dt>
-        <dd>Name of the appliance.</dd>
+        <dd>Name of the appliance, matched <b>exactly</b> as shown in the Grohe Ondus app. If the room / name does not match, the node logs the available names. If valve commands time out while reading works, the name is likely resolving to a stale, no longer registered appliance &ndash; rename it in the app and re-select it here.</dd>
         <dt>Type <span class="property-type">number</span></dt>
         <dd>Device type: <code>101</code> = Sense, <code>102</code> = Sense Plus, <code>103</code> = Sense Guard.</dd>
         <dt>Description <span class="property-type">string</span></dt>

--- a/grohe/lib/locator.js
+++ b/grohe/lib/locator.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Resolves the location / room / appliance ids for a given room + appliance name.
+// Appliances are matched by their exact name (as shown in the Grohe Ondus app).
+//
+// On success returns:
+//   { ids: { locationId, roomId, applianceId }, registrationComplete: boolean }
+// On failure returns a diagnostic object so the caller can tell the user what is
+// actually available instead of a cryptic timeout / "not found":
+//   { error: 'roomNotFound', availableRooms: [...] }
+//   { error: 'applianceNotFound', availableRooms: [...], availableAppliances: [...] }
+// (#25)
+function findApplianceIds(location, appliancesByRoomName, roomName, applianceName) {
+    let availableRooms = Object.keys(appliancesByRoomName || {});
+
+    let entry = (appliancesByRoomName || {})[roomName];
+    if (entry === undefined) {
+        return {
+            error: 'roomNotFound',
+            availableRooms: availableRooms,
+        };
+    }
+
+    let appliances = entry.appliances || [];
+    let room = entry.room || {};
+
+    for (let i = 0; i < appliances.length; i++) {
+        let appliance = appliances[i];
+
+        if (appliance.name === applianceName) {
+            return {
+                ids: {
+                    locationId: location.id,
+                    roomId: room.id,
+                    applianceId: appliance.appliance_id,
+                },
+                // Stale / not fully registered appliances still resolve but their
+                // commands typically time out, so flag them for the caller.
+                registrationComplete: appliance.registration_complete !== false,
+            };
+        }
+    }
+
+    return {
+        error: 'applianceNotFound',
+        availableRooms: availableRooms,
+        availableAppliances: appliances.map(function (a) { return a.name; }),
+    };
+}
+
+module.exports = {
+    findApplianceIds,
+};

--- a/grohe/nodes/grohe-location-node.js
+++ b/grohe/nodes/grohe-location-node.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const ondusApi = require('../lib/ondusApi.js');
+const locator = require('../lib/locator.js');
 
 module.exports = function (RED) {
     // The configuration node holds the username and password
@@ -15,7 +16,9 @@ module.exports = function (RED) {
 
         let node = this;
         node.config = n;
-        node.locationName = n.location;
+        // Trim so accidental leading / trailing whitespace does not silently
+        // break the exact name match against the dashboard. (#25)
+        node.locationName = (n.location || '').trim();
         node.connected = false;
 
         node.appliancesByRoomName = {};
@@ -87,31 +90,14 @@ module.exports = function (RED) {
             done();
         });
 
+        // Returns the full diagnostic lookup result (see lib/locator.js).
+        this.findAppliance = function (roomName, applianceName) {
+            return locator.findApplianceIds(node.location, node.appliancesByRoomName, roomName, applianceName);
+        };
+
+        // Back-compat: returns the ids object on success or undefined on failure.
         this.getApplianceIds = function (roomName, applianceName) {
-
-            let applianceIds;
-
-            if (node.appliancesByRoomName[roomName] !== undefined) {
-                let value = node.appliancesByRoomName[roomName];
-
-                let appliances = value.appliances;
-                let room = value.room;
-                for (let i = 0; i < appliances.length; i++) {
-                    let appliance = appliances[i];
-
-                    if (appliance.name === applianceName) {
-                        applianceIds = {
-                            locationId: node.location.id,
-                            roomId: room.id,
-                            applianceId: appliance.appliance_id, // why not id here?
-                        };
-
-                        break;
-                    }
-                }
-            }
-
-            return applianceIds;
+            return node.findAppliance(roomName, applianceName).ids;
         };
     }
 

--- a/grohe/nodes/grohe-sense-node.js
+++ b/grohe/nodes/grohe-sense-node.js
@@ -27,9 +27,16 @@ module.exports = function (RED) {
 
             node.onInitialized = function () {
 
-                node.applianceIds = node.config.getApplianceIds(node.roomName, node.applianceName);
+                let lookup = node.config.findAppliance(node.roomName, node.applianceName);
+                node.applianceIds = lookup.ids;
                 if (node.applianceIds !== undefined) {
                     node.status({ fill: 'green', shape: 'ring', text: 'connected' });
+
+                    // A stale / not fully registered appliance resolves but its
+                    // commands typically time out - warn so the cause is obvious. (#25)
+                    if (lookup.registrationComplete === false) {
+                        node.warn('Grohe appliance "' + node.applianceName + '" is not fully registered in the Grohe app - commands (e.g. open / close valve) may time out.');
+                    }
 
                     node.on('input', async function (msg) {
 
@@ -188,7 +195,19 @@ module.exports = function (RED) {
                     });
                 }
                 else {
-                    node.status({ fill: 'red', shape: 'ring', text: node.applianceName + ' not found ' });
+                    // Tell the user what is actually available instead of leaving
+                    // them to guess at a name mismatch. (#25)
+                    let hint;
+                    if (lookup.error === 'roomNotFound') {
+                        hint = 'room "' + node.roomName + '" not found. Available rooms: ' +
+                            (lookup.availableRooms.join(', ') || '(none)');
+                    }
+                    else {
+                        hint = 'appliance "' + node.applianceName + '" not found in room "' + node.roomName +
+                            '". Available appliances: ' + (lookup.availableAppliances.join(', ') || '(none)');
+                    }
+                    node.warn('Grohe Sense: ' + hint + '. Names must match the Grohe app exactly (including spaces and capitalization).');
+                    node.status({ fill: 'red', shape: 'ring', text: node.applianceName + ' not found' });
                 }
 
             };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-grohe-sense",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-grohe-sense",
-            "version": "0.29.0",
+            "version": "0.30.0",
             "license": "MIT",
             "dependencies": {
                 "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-grohe-sense",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "description": "Grohe sense nodes via ondus API.",
     "node-red": {
         "version": ">=0.1.0",

--- a/test/locator.test.js
+++ b/test/locator.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const assert = require('assert');
+const locator = require('../grohe/lib/locator');
+
+describe('lib/locator', function () {
+
+    const location = { id: 'loc-1' };
+
+    function makeAppliancesByRoomName() {
+        return {
+            'Wasserkeller': {
+                room: { id: 'room-1', name: 'Wasserkeller' },
+                appliances: [
+                    { appliance_id: 'app-1', name: 'SenseGuard', registration_complete: true },
+                    { appliance_id: 'app-2', name: 'Ghost', registration_complete: false },
+                    { appliance_id: 'app-3', name: 'NoFlag' },
+                ],
+            },
+            'WC': {
+                room: { id: 'room-2', name: 'WC' },
+                appliances: [
+                    { appliance_id: 'app-4', name: 'Sense1', registration_complete: true },
+                ],
+            },
+        };
+    }
+
+    describe('findApplianceIds', function () {
+        it('resolves ids for a matching room + appliance', function () {
+            const result = locator.findApplianceIds(location, makeAppliancesByRoomName(), 'Wasserkeller', 'SenseGuard');
+            assert.deepStrictEqual(result.ids, {
+                locationId: 'loc-1',
+                roomId: 'room-1',
+                applianceId: 'app-1',
+            });
+            assert.strictEqual(result.registrationComplete, true);
+            assert.ok(!('error' in result));
+        });
+
+        it('flags an appliance that is not fully registered', function () {
+            const result = locator.findApplianceIds(location, makeAppliancesByRoomName(), 'Wasserkeller', 'Ghost');
+            assert.strictEqual(result.ids.applianceId, 'app-2');
+            assert.strictEqual(result.registrationComplete, false);
+        });
+
+        it('treats a missing registration_complete flag as registered', function () {
+            const result = locator.findApplianceIds(location, makeAppliancesByRoomName(), 'Wasserkeller', 'NoFlag');
+            assert.strictEqual(result.registrationComplete, true);
+        });
+
+        it('reports roomNotFound with the available room names', function () {
+            const result = locator.findApplianceIds(location, makeAppliancesByRoomName(), 'Garage', 'SenseGuard');
+            assert.strictEqual(result.error, 'roomNotFound');
+            assert.deepStrictEqual(result.availableRooms, ['Wasserkeller', 'WC']);
+            assert.ok(!('ids' in result));
+        });
+
+        it('reports applianceNotFound with the available appliance names', function () {
+            const result = locator.findApplianceIds(location, makeAppliancesByRoomName(), 'Wasserkeller', 'IL MIO GUARD');
+            assert.strictEqual(result.error, 'applianceNotFound');
+            assert.deepStrictEqual(result.availableRooms, ['Wasserkeller', 'WC']);
+            assert.deepStrictEqual(result.availableAppliances, ['SenseGuard', 'Ghost', 'NoFlag']);
+        });
+
+        it('does not match names that differ only by surrounding whitespace', function () {
+            const result = locator.findApplianceIds(location, makeAppliancesByRoomName(), 'Wasserkeller', 'SenseGuard ');
+            assert.strictEqual(result.error, 'applianceNotFound');
+        });
+
+        it('handles an empty appliancesByRoomName without throwing', function () {
+            const result = locator.findApplianceIds(location, {}, 'Wasserkeller', 'SenseGuard');
+            assert.strictEqual(result.error, 'roomNotFound');
+            assert.deepStrictEqual(result.availableRooms, []);
+        });
+    });
+
+});


### PR DESCRIPTION
Closes #25.

## Background

In #25 a user hit `Caught exception: Request Timeout` on valve open/close while reading worked. After a long back-and-forth it "fixed itself" after renaming the device, and the thread concluded *"names with spaces"* were to blame.

Tracing the code shows that's a red herring: appliances are matched **by exact name locally** ([locator]), and the actual valve POST is built from **IDs, not names** ([ondusApi.js](grohe/lib/ondusApi.js)), so a space can't reach the request. The real cause was a **stale / duplicate appliance** (the user's first dump shows `registration_complete:false` and frozen 2024 data) — the configured name resolved to a dead ghost whose commands timed out, while Get Data returned its cached data. Renaming forced resolution to the live appliance.

So rather than blocking spaces (which would reject legitimate names like "Living Room"), this PR makes the failure **self-diagnosing**.

## Changes

- **`lib/locator.js` (new, unit-tested):** `findApplianceIds` returns `{ids, registrationComplete}` on success, or a diagnostic `{error, availableRooms[, availableAppliances]}` on failure.
- **Sense node:** on mismatch, logs the available room / appliance names (instead of a bare "not found"); warns when a matched appliance has `registration_complete:false` — the actual cause of command timeouts.
- **Location node:** delegates to the locator (keeps `getApplianceIds` as a back-compat wrapper) and trims the location name like room/appliance already are.
- **Docs:** README + node help now state names must match the Grohe app exactly (incl. spaces) and explain the stale-appliance timeout symptom.
- **Tests:** 7 new locator tests (success, stale flag, missing flag, room/appliance not found with available-name lists, whitespace, empty cache).

## Verification

`npm run lint` clean, `npm test` -> 36 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)