### PR TITLE
Auto-reconnect when the internet is unavailable (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.31.0] [2026-06-27]
+### the location node now keeps retrying login with exponential backoff (5s..60s) when the internet is unavailable at startup or the connection is later lost (incl. a failed token refresh), and recovers automatically; sense nodes show 'disconnected' and reconnect without stacking duplicate input handlers; added connection log messages - [#20](https://github.com/windkh/node-red-contrib-grohe-sense/issues/20)
+
 ## [0.30.0] [2026-06-27]
 ### improved appliance lookup diagnostics: room / appliance names are now matched via a unit-tested lib/locator helper that, on mismatch, reports the available names; the node warns when a matched appliance is not fully registered (stale appliances cause command timeouts); location name is trimmed - [#25](https://github.com/windkh/node-red-contrib-grohe-sense/issues/25)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Holds the Ondus credentials and identifies the location to operate on.
 | Username | string | Email of the Grohe Ondus account. |
 | Password | string | Password of the Grohe Ondus account (stored encrypted by Node-RED). |
 
-On startup the node logs in, retrieves the dashboard, and caches the rooms and appliances of the configured location. The access token is automatically refreshed every 30 minutes; short internet outages are tolerated.
+On startup the node logs in, retrieves the dashboard, and caches the rooms and appliances of the configured location. The access token is automatically refreshed every 30 minutes.
+
+If the internet is unavailable at startup (or the connection is later lost — including a failed token refresh), the node keeps retrying the login with exponential backoff (5s up to 60s) and recovers automatically once connectivity returns. Connection attempts, successes, and failures are written to the Node-RED log to aid debugging. While disconnected, the dependent `grohe sense` nodes show *disconnected*. (see [#20](https://github.com/windkh/node-red-contrib-grohe-sense/issues/20))
 
 
 ## `grohe sense`
@@ -115,7 +117,7 @@ Any incoming message triggers a poll. The optional fields on `msg.payload` contr
 | `statistics` | object | Pre-computed min/max temperature, humidity, pressure, flow rate, and today/total water consumption derived from `data`. |
 
 ### Status indicator
-The node icon reflects the runtime state: *initializing*, *connected*, *updating*, *ok*, *N notifications*, or *failed*.
+The node icon reflects the runtime state: *connecting*, *connected*, *updating*, *ok*, *N notifications*, *disconnected*, *&lt;name&gt; not found*, or *failed*. When the configuration node loses its connection the sense node shows *disconnected* and automatically returns to *connected* once the connection is re-established.
 
 
 ## Examples

--- a/grohe/99-grohe.html
+++ b/grohe/99-grohe.html
@@ -53,7 +53,8 @@
     </dl>
 
     <h3>Details</h3>
-    <p>On startup the node logs in to <code>idp2-apigw.cloud.grohe.com</code>, retrieves the dashboard, and caches the rooms and appliances of the configured location. The access token is automatically refreshed every 30 minutes. If the network is temporarily unavailable, the refresh is retried and the node recovers automatically (as long as the outage is shorter than the refresh-token lifetime of ~1 hour).</p>
+    <p>On startup the node logs in to <code>idp2-apigw.cloud.grohe.com</code>, retrieves the dashboard, and caches the rooms and appliances of the configured location. The access token is automatically refreshed every 30 minutes.</p>
+    <p>If the internet is unavailable at startup, or the connection is later lost (including a failed token refresh), the node keeps retrying the login with exponential backoff (5&nbsp;s up to 60&nbsp;s) and recovers automatically once connectivity returns. Connection attempts, successes and failures are written to the Node-RED log. While disconnected the dependent <code>grohe sense</code> nodes show <i>disconnected</i>.</p>
 </script>
 
 
@@ -173,7 +174,7 @@
     </dl>
 
     <h3>Status</h3>
-    <p>The node icon reflects the runtime state: <em>initializing</em>, <em>connected</em>, <em>updating</em>, <em>ok</em>, <em>N notifications</em>, or <em>failed</em>.</p>
+    <p>The node icon reflects the runtime state: <em>connecting</em>, <em>connected</em>, <em>updating</em>, <em>ok</em>, <em>N notifications</em>, <em>disconnected</em>, <em>&lt;name&gt; not found</em>, or <em>failed</em>. When the configuration node loses its connection the node shows <em>disconnected</em> and returns to <em>connected</em> automatically once it reconnects.</p>
 
     <h3>Examples</h3>
     <p>See the flows in the <code>examples/</code> folder of this package for ready-to-import sample flows.</p>

--- a/grohe/lib/backoff.js
+++ b/grohe/lib/backoff.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Exponential backoff with a cap, used by the location node reconnect loop. (#20)
+// attempt is 0-based: 0 -> baseMs, 1 -> 2*baseMs, 2 -> 4*baseMs, ... capped at maxMs.
+function computeBackoffDelay(attempt, baseMs, maxMs) {
+    if (!(attempt > 0)) { // also normalizes NaN / negative to 0
+        attempt = 0;
+    }
+
+    let delay = baseMs * Math.pow(2, attempt);
+    if (!(delay <= maxMs)) { // also catches Infinity from very large attempts
+        delay = maxMs;
+    }
+
+    return delay;
+}
+
+module.exports = {
+    computeBackoffDelay,
+};

--- a/grohe/lib/ondusApi.js
+++ b/grohe/lib/ondusApi.js
@@ -195,12 +195,19 @@ class OndusSession {
             });
     };
 
-    start() {
+    // onError (optional) is invoked when a scheduled token refresh fails, e.g.
+    // because the internet connection was lost. This lets the caller tear the
+    // session down and re-enter its reconnect loop instead of silently dying. (#20)
+    start(onError) {
         let session = this;
 
         let interval = 1000 * session.accessTokenExpiresIn / 2; // 1800s
         session.refreshTimer = setInterval(function() {
-            session.refreshAccessToken();
+            session.refreshAccessToken().catch(function (error) {
+                if (typeof onError === 'function') {
+                    onError(error);
+                }
+            });
         }, interval);
     };
 
@@ -330,7 +337,9 @@ class OndusSession {
 };
 
 // Exported Methds
-async function login(username, password) {
+// onRefreshFailed (optional) is forwarded to session.start() and called if a
+// scheduled token refresh later fails. (#20)
+async function login(username, password, onRefreshFailed) {
 
     let session = new OndusSession();
 
@@ -338,7 +347,7 @@ async function login(username, password) {
     await session.getTokenUrl(username, password);
     await session.getRefreshToken();
 
-    session.start();
+    session.start(onRefreshFailed);
     return session;
 }
 

--- a/grohe/nodes/grohe-location-node.js
+++ b/grohe/nodes/grohe-location-node.js
@@ -7,6 +7,20 @@
 
 const ondusApi = require('../lib/ondusApi.js');
 const locator = require('../lib/locator.js');
+const backoff = require('../lib/backoff.js');
+
+const RECONNECT_BASE_MS = 5000;
+const RECONNECT_MAX_MS = 60000;
+
+function describeError(exception) {
+    if (exception === undefined || exception === null) {
+        return 'unknown error';
+    }
+    if (exception.message) {
+        return exception.message;
+    }
+    return String(exception);
+}
 
 module.exports = function (RED) {
     // The configuration node holds the username and password
@@ -22,66 +36,153 @@ module.exports = function (RED) {
         node.connected = false;
 
         node.appliancesByRoomName = {};
+        node.closing = false;
+        node.reconnectTimer = undefined;
+        node.reconnectAttempt = 0;
 
-        if (node.credentials !== undefined && node.credentials.username !== undefined && node.credentials.password !== undefined
-            && node.credentials.username !== '' && node.credentials.password !== '') {
+        let hasCredentials = node.credentials !== undefined
+            && node.credentials.username !== undefined && node.credentials.username !== ''
+            && node.credentials.password !== undefined && node.credentials.password !== '';
 
-            (async () => {
+        // Tear down the current session (e.g. after the connection was lost). (#20)
+        node.disconnect = function () {
+            if (node.session && typeof node.session.stop === 'function') {
+                ondusApi.logoff(node.session);
+            }
+            node.session = undefined;
+            if (node.connected) {
+                node.connected = false;
+                node.emit('disconnected');
+            }
+        };
 
-                try {
-                    node.session = await ondusApi.login(node.credentials.username, node.credentials.password);
+        // Schedule the next connection attempt with exponential backoff. (#20)
+        node.scheduleReconnect = function () {
+            if (node.closing) {
+                return;
+            }
 
-                    let response = await node.session.getDahsboard();
-                    let dashboard = JSON.parse(response.text);
+            let delay = backoff.computeBackoffDelay(node.reconnectAttempt, RECONNECT_BASE_MS, RECONNECT_MAX_MS);
+            node.reconnectAttempt++;
+            node.log('Grohe: next connection attempt in ' + Math.round(delay / 1000) + 's.');
 
-                    let locations = dashboard.locations;
+            node.reconnectTimer = setTimeout(function () {
+                node.reconnectTimer = undefined;
+                node.connect();
+            }, delay);
+        };
 
-                    for (let i = 0; i < locations.length; i++) {
-                        let location = locations[i];
+        // Called by the refresh timer when a scheduled token refresh fails,
+        // e.g. because the internet connection was lost. (#20)
+        node.onRefreshFailed = function (exception) {
+            if (node.closing || !node.connected) {
+                return;
+            }
+            node.warn('Grohe: token refresh failed (' + describeError(exception) + '), reconnecting...');
+            node.disconnect();
+            node.reconnectAttempt = 0; // recover quickly after a lost connection
+            node.scheduleReconnect();
+        };
 
-                        if (location.name === node.locationName) {
-                            node.location = location;
-                            node.log('location ' + location.name);
+        node.connect = async function () {
+            if (node.closing) {
+                return;
+            }
 
-                            node.rooms = location.rooms;
+            node.log('Grohe: connecting to the ondus cloud...');
+            node.emit('connecting');
 
-                            for (let j = 0; j < node.rooms.length; j++) {
-                                let room = node.rooms[j];
-                                node.log('    room ' + room.name);
+            let session;
+            let dashboard;
+            try {
+                session = await ondusApi.login(node.credentials.username, node.credentials.password, node.onRefreshFailed);
 
-                                let appliances = room.appliances;
-                                node.appliancesByRoomName[room.name] = {
-                                    room: room,
-                                    appliances: appliances,
-                                };
+                let response = await session.getDahsboard();
+                dashboard = JSON.parse(response.text);
+            }
+            catch (exception) {
+                // Connectivity / authentication problem - keep retrying so the node
+                // recovers automatically once the internet is back. (#20)
+                node.connected = false;
+                node.emit('initializeFailed', exception);
+                node.emit('disconnected');
+                node.warn('Grohe: connection failed: ' + describeError(exception) + '.');
+                node.scheduleReconnect();
+                return;
+            }
 
-                                for (let k = 0; k < appliances.length; k++) {
-                                    let appliance = appliances[k];
-                                    node.log('        appliance ' + appliance.name);
-                                }
-                            }
+            node.session = session;
 
-                            node.connected = true;
-                            node.emit('initialized');
-                            break;
-                        }
-                    }
+            let locations = dashboard.locations || [];
+            let foundLocation;
+            for (let i = 0; i < locations.length; i++) {
+                if (locations[i].name === node.locationName) {
+                    foundLocation = locations[i];
+                    break;
                 }
-                catch (exception) {
-                    node.connected = false;
-                    node.emit('initializeFailed', exception);
-                    node.warn(exception);
+            }
+
+            if (foundLocation === undefined) {
+                // Login worked but the configured location does not exist - this is a
+                // configuration error, not a connectivity one, so do not spin the
+                // retry loop. Surface it so the user can fix the name.
+                node.disconnect();
+                node.emit('initializeFailed', 'location "' + node.locationName + '" not found');
+                node.emit('disconnected');
+                node.warn('Grohe: location "' + node.locationName + '" not found in the account. Available locations: ' +
+                    (locations.map(function (l) { return l.name; }).join(', ') || '(none)') + '.');
+                return;
+            }
+
+            node.location = foundLocation;
+            node.rooms = foundLocation.rooms || [];
+            node.appliancesByRoomName = {};
+            node.log('Grohe: location ' + foundLocation.name);
+
+            for (let j = 0; j < node.rooms.length; j++) {
+                let room = node.rooms[j];
+                node.log('Grohe:     room ' + room.name);
+
+                let appliances = room.appliances || [];
+                node.appliancesByRoomName[room.name] = {
+                    room: room,
+                    appliances: appliances,
+                };
+
+                for (let k = 0; k < appliances.length; k++) {
+                    node.log('Grohe:         appliance ' + appliances[k].name);
                 }
-            })();
+            }
+
+            node.reconnectAttempt = 0;
+            node.connected = true;
+            node.log('Grohe: connected.');
+            node.emit('initialized');
+            node.emit('connected');
+        };
+
+        if (hasCredentials) {
+            node.connect();
         }
         else {
-            node.connected = false;
-            node.emit('initializeFailed', 'credentials missing');
-            node.warn('credentials missing');
+            // Defer so sense nodes (created after this config node) can subscribe first.
+            setImmediate(function () {
+                node.connected = false;
+                node.emit('initializeFailed', 'credentials missing');
+                node.emit('disconnected');
+                node.warn('credentials missing');
+            });
         }
 
         this.on('close', function (done) {
-            ondusApi.logoff(node.session);
+            node.closing = true;
+            if (node.reconnectTimer !== undefined) {
+                clearTimeout(node.reconnectTimer);
+                node.reconnectTimer = undefined;
+            }
+            if (node.session && typeof node.session.stop === 'function') {
+                ondusApi.logoff(node.session);
+            }
             node.session = {};
             node.location = {};
             node.rooms = {};

--- a/grohe/nodes/grohe-sense-node.js
+++ b/grohe/nodes/grohe-sense-node.js
@@ -21,12 +21,12 @@ module.exports = function (RED) {
         node.config = RED.nodes.getNode(node.location);
         if (node.config) {
 
-            node.locationId = node.config.locationId;
+            node.applianceIds = undefined;
 
-            node.status({ fill: 'red', shape: 'ring', text: 'initializing' });
+            node.status({ fill: 'red', shape: 'ring', text: 'connecting' });
 
-            node.onInitialized = function () {
-
+            // (Re)resolve the appliance whenever the config node (re)connects. (#20, #25)
+            node.resolveAppliance = function () {
                 let lookup = node.config.findAppliance(node.roomName, node.applianceName);
                 node.applianceIds = lookup.ids;
                 if (node.applianceIds !== undefined) {
@@ -37,162 +37,6 @@ module.exports = function (RED) {
                     if (lookup.registrationComplete === false) {
                         node.warn('Grohe appliance "' + node.applianceName + '" is not fully registered in the Grohe app - commands (e.g. open / close valve) may time out.');
                     }
-
-                    node.on('input', async function (msg) {
-
-                        try {
-                            node.status({ fill: 'green', shape: 'ring', text: 'updating...' });
-
-                            if (node.devicetype === ondusApi.OndusType.SenseGuard) {
-                                if (msg.payload !== undefined && msg.payload.command !== undefined) {
-                                    let data = msg.payload;
-                                    data.type = node.devicetype;
-                                    await node.config.session.setApplianceCommand(
-                                        node.applianceIds.locationId,
-                                        node.applianceIds.roomId,
-                                        node.applianceIds.applianceId,
-                                        data);
-                                    // Hint: response is not used right now.
-                                }
-                            }
-
-                            let responseInfo = await node.config.session.getApplianceInfo(
-                                node.applianceIds.locationId,
-                                node.applianceIds.roomId,
-                                node.applianceIds.applianceId);
-                            let info = JSON.parse(responseInfo.text);
-
-                            let responseStatus = await node.config.session.getApplianceStatus(
-                                node.applianceIds.locationId,
-                                node.applianceIds.roomId,
-                                node.applianceIds.applianceId);
-                            let status = JSON.parse(responseStatus.text);
-
-                            let responseDetails = await node.config.session.getApplianceDetails(
-                                node.applianceIds.locationId,
-                                node.applianceIds.roomId,
-                                node.applianceIds.applianceId);
-                            let details = JSON.parse(responseDetails.text);
-
-                            let responseNotifications = await node.config.session.getApplianceNotifications(
-                                node.applianceIds.locationId,
-                                node.applianceIds.roomId,
-                                node.applianceIds.applianceId);
-                            let notifications = JSON.parse(responseNotifications.text);
-
-                            let data;
-                            if (msg.payload !== undefined && msg.payload.data !== undefined) {
-                                let fromDate = converters.convertToDate(msg.payload.data.from);
-                                let toDate = converters.convertToDate(msg.payload.data.to);
-                                let groupBy = msg.payload.data.groupBy;
-                                try {
-                                    let responseData = await node.config.session.getApplianceData(
-                                        node.applianceIds.locationId,
-                                        node.applianceIds.roomId,
-                                        node.applianceIds.applianceId,
-                                        fromDate,
-                                        toDate,
-                                        groupBy);
-                                    data = JSON.parse(responseData.text);
-                                }
-                                catch (exception) {
-                                    let errorMessage = 'getApplianceData failed: ' + exception.message;
-                                    node.error(errorMessage, msg);
-                                    node.status({ fill: 'red', shape: 'ring', text: 'failed' });
-                                }
-                            }
-
-                            // For Debugging only
-                            if (msg.debug === true) {
-                                let debugMsg = {
-                                    debug: {
-                                        applianceIds: node.applianceIds,
-                                        info: info,
-                                        status: status,
-                                        details: details,
-                                        notifications: notifications,
-                                        applianceData: data,
-                                    },
-                                };
-                                node.warn(debugMsg);
-                            }
-
-                            let result = {};
-
-                            if (info != null) {
-                                result.info = info;
-                            }
-
-                            if (status != null) {
-                                result.status = converters.convertStatus(status);
-                            }
-
-                            if (details != null) {
-                                result.details = details;
-
-                                // The changed api exposes the most recent reading directly
-                                // in details.data_latest. Surface its parts as first-class
-                                // fields so the current measurement / latest withdrawal /
-                                // consumption summary is available without requesting
-                                // historical data. (#27, #26)
-                                let dataLatest = details.data_latest;
-                                if (dataLatest != null) {
-                                    if (dataLatest.measurement != null) {
-                                        result.measurement = dataLatest.measurement;
-                                    }
-
-                                    // Sense Guard only: latest withdrawal + consumption summary.
-                                    if (dataLatest.withdrawals != null) {
-                                        result.withdrawal = dataLatest.withdrawals;
-                                    }
-
-                                    let consumption = converters.convertConsumption(dataLatest);
-                                    if (consumption != null) {
-                                        result.consumption = consumption;
-                                    }
-                                }
-                            }
-
-                            if (notifications != null) {
-                                result.notifications = converters.convertNotifications(notifications);
-                            }
-
-                            if (data != null) {
-                                result.data = data.data;
-                                result.statistics = converters.convertData(data.data);
-                            }
-
-                            if (info[0].type === ondusApi.OndusType.SenseGuard) {
-                                let response4 = await node.config.session.getApplianceCommand(
-                                    node.applianceIds.locationId,
-                                    node.applianceIds.roomId,
-                                    node.applianceIds.applianceId);
-                                let command = JSON.parse(response4.text);
-                                result.command = command.command;
-                                // Here timestamp could also be interesting in future.
-                            }
-
-                            msg.payload = result;
-                            node.send([msg]);
-
-                            let notificationCount = 0;
-                            if (notifications !== undefined) {
-                                notificationCount = notifications.length;
-                            }
-
-                            if (notificationCount === 0) {
-                                node.status({ fill: 'green', shape: 'ring', text: 'ok' });
-                            }
-                            else {
-                                node.status({ fill: 'yellow', shape: 'dot', text: notificationCount + ' notifications' });
-                            }
-                        }
-                        catch (exception) {
-                            let errorMessage = 'Caught exception: ' + exception.message;
-                            node.error(errorMessage, msg);
-                            node.status({ fill: 'red', shape: 'ring', text: 'failed' });
-                        }
-                    });
                 }
                 else {
                     // Tell the user what is actually available instead of leaving
@@ -209,24 +53,196 @@ module.exports = function (RED) {
                     node.warn('Grohe Sense: ' + hint + '. Names must match the Grohe app exactly (including spaces and capitalization).');
                     node.status({ fill: 'red', shape: 'ring', text: node.applianceName + ' not found' });
                 }
-
             };
-            node.config.addListener('initialized', node.onInitialized);
+
+            node.onConnected = function () {
+                node.resolveAppliance();
+            };
+
+            node.onDisconnected = function () {
+                node.applianceIds = undefined;
+                node.status({ fill: 'red', shape: 'ring', text: 'disconnected' });
+            };
 
             node.onError = function (errorMessage) {
-                node.status({ fill: 'red', shape: 'ring', text: errorMessage });
+                node.applianceIds = undefined;
+                node.status({ fill: 'red', shape: 'ring', text: typeof errorMessage === 'string' ? errorMessage : 'disconnected' });
             };
+
+            node.config.addListener('connected', node.onConnected);
+            node.config.addListener('disconnected', node.onDisconnected);
             node.config.addListener('initializeFailed', node.onError);
 
+            // The config node may already be connected (e.g. on a partial redeploy).
+            if (node.config.connected) {
+                node.resolveAppliance();
+            }
+
+            node.on('input', async function (msg) {
+
+                if (node.applianceIds === undefined) {
+                    node.warn('Grohe Sense: not connected (or appliance not resolved) - ignoring input.');
+                    return;
+                }
+
+                try {
+                    node.status({ fill: 'green', shape: 'ring', text: 'updating...' });
+
+                    if (node.devicetype === ondusApi.OndusType.SenseGuard) {
+                        if (msg.payload !== undefined && msg.payload.command !== undefined) {
+                            let data = msg.payload;
+                            data.type = node.devicetype;
+                            await node.config.session.setApplianceCommand(
+                                node.applianceIds.locationId,
+                                node.applianceIds.roomId,
+                                node.applianceIds.applianceId,
+                                data);
+                            // Hint: response is not used right now.
+                        }
+                    }
+
+                    let responseInfo = await node.config.session.getApplianceInfo(
+                        node.applianceIds.locationId,
+                        node.applianceIds.roomId,
+                        node.applianceIds.applianceId);
+                    let info = JSON.parse(responseInfo.text);
+
+                    let responseStatus = await node.config.session.getApplianceStatus(
+                        node.applianceIds.locationId,
+                        node.applianceIds.roomId,
+                        node.applianceIds.applianceId);
+                    let status = JSON.parse(responseStatus.text);
+
+                    let responseDetails = await node.config.session.getApplianceDetails(
+                        node.applianceIds.locationId,
+                        node.applianceIds.roomId,
+                        node.applianceIds.applianceId);
+                    let details = JSON.parse(responseDetails.text);
+
+                    let responseNotifications = await node.config.session.getApplianceNotifications(
+                        node.applianceIds.locationId,
+                        node.applianceIds.roomId,
+                        node.applianceIds.applianceId);
+                    let notifications = JSON.parse(responseNotifications.text);
+
+                    let data;
+                    if (msg.payload !== undefined && msg.payload.data !== undefined) {
+                        let fromDate = converters.convertToDate(msg.payload.data.from);
+                        let toDate = converters.convertToDate(msg.payload.data.to);
+                        let groupBy = msg.payload.data.groupBy;
+                        try {
+                            let responseData = await node.config.session.getApplianceData(
+                                node.applianceIds.locationId,
+                                node.applianceIds.roomId,
+                                node.applianceIds.applianceId,
+                                fromDate,
+                                toDate,
+                                groupBy);
+                            data = JSON.parse(responseData.text);
+                        }
+                        catch (exception) {
+                            let errorMessage = 'getApplianceData failed: ' + exception.message;
+                            node.error(errorMessage, msg);
+                            node.status({ fill: 'red', shape: 'ring', text: 'failed' });
+                        }
+                    }
+
+                    // For Debugging only
+                    if (msg.debug === true) {
+                        let debugMsg = {
+                            debug: {
+                                applianceIds: node.applianceIds,
+                                info: info,
+                                status: status,
+                                details: details,
+                                notifications: notifications,
+                                applianceData: data,
+                            },
+                        };
+                        node.warn(debugMsg);
+                    }
+
+                    let result = {};
+
+                    if (info != null) {
+                        result.info = info;
+                    }
+
+                    if (status != null) {
+                        result.status = converters.convertStatus(status);
+                    }
+
+                    if (details != null) {
+                        result.details = details;
+
+                        // The changed api exposes the most recent reading directly
+                        // in details.data_latest. Surface its parts as first-class
+                        // fields so the current measurement / latest withdrawal /
+                        // consumption summary is available without requesting
+                        // historical data. (#27, #26)
+                        let dataLatest = details.data_latest;
+                        if (dataLatest != null) {
+                            if (dataLatest.measurement != null) {
+                                result.measurement = dataLatest.measurement;
+                            }
+
+                            // Sense Guard only: latest withdrawal + consumption summary.
+                            if (dataLatest.withdrawals != null) {
+                                result.withdrawal = dataLatest.withdrawals;
+                            }
+
+                            let consumption = converters.convertConsumption(dataLatest);
+                            if (consumption != null) {
+                                result.consumption = consumption;
+                            }
+                        }
+                    }
+
+                    if (notifications != null) {
+                        result.notifications = converters.convertNotifications(notifications);
+                    }
+
+                    if (data != null) {
+                        result.data = data.data;
+                        result.statistics = converters.convertData(data.data);
+                    }
+
+                    if (info[0].type === ondusApi.OndusType.SenseGuard) {
+                        let response4 = await node.config.session.getApplianceCommand(
+                            node.applianceIds.locationId,
+                            node.applianceIds.roomId,
+                            node.applianceIds.applianceId);
+                        let command = JSON.parse(response4.text);
+                        result.command = command.command;
+                        // Here timestamp could also be interesting in future.
+                    }
+
+                    msg.payload = result;
+                    node.send([msg]);
+
+                    let notificationCount = 0;
+                    if (notifications !== undefined) {
+                        notificationCount = notifications.length;
+                    }
+
+                    if (notificationCount === 0) {
+                        node.status({ fill: 'green', shape: 'ring', text: 'ok' });
+                    }
+                    else {
+                        node.status({ fill: 'yellow', shape: 'dot', text: notificationCount + ' notifications' });
+                    }
+                }
+                catch (exception) {
+                    let errorMessage = 'Caught exception: ' + exception.message;
+                    node.error(errorMessage, msg);
+                    node.status({ fill: 'red', shape: 'ring', text: 'failed' });
+                }
+            });
+
             this.on('close', function () {
-                if (node.onInitialized) {
-                    node.config.removeListener('initialized', node.onInitialized);
-                }
-
-                if (node.onError) {
-                    node.config.removeListener('initializeFailed', node.onError);
-                }
-
+                node.config.removeListener('connected', node.onConnected);
+                node.config.removeListener('disconnected', node.onDisconnected);
+                node.config.removeListener('initializeFailed', node.onError);
                 node.status({});
             });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-grohe-sense",
-    "version": "0.30.0",
+    "version": "0.31.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-grohe-sense",
-            "version": "0.30.0",
+            "version": "0.31.0",
             "license": "MIT",
             "dependencies": {
                 "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-grohe-sense",
-    "version": "0.30.0",
+    "version": "0.31.0",
     "description": "Grohe sense nodes via ondus API.",
     "node-red": {
         "version": ">=0.1.0",

--- a/test/backoff.test.js
+++ b/test/backoff.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const assert = require('assert');
+const backoff = require('../grohe/lib/backoff');
+
+describe('lib/backoff', function () {
+
+    describe('computeBackoffDelay', function () {
+        it('returns the base delay for the first attempt', function () {
+            assert.strictEqual(backoff.computeBackoffDelay(0, 5000, 60000), 5000);
+        });
+
+        it('doubles the delay with each attempt', function () {
+            assert.strictEqual(backoff.computeBackoffDelay(1, 5000, 60000), 10000);
+            assert.strictEqual(backoff.computeBackoffDelay(2, 5000, 60000), 20000);
+            assert.strictEqual(backoff.computeBackoffDelay(3, 5000, 60000), 40000);
+        });
+
+        it('caps the delay at maxMs', function () {
+            assert.strictEqual(backoff.computeBackoffDelay(4, 5000, 60000), 60000);
+            assert.strictEqual(backoff.computeBackoffDelay(100, 5000, 60000), 60000);
+        });
+
+        it('normalizes negative / NaN attempts to the base delay', function () {
+            assert.strictEqual(backoff.computeBackoffDelay(-1, 5000, 60000), 5000);
+            assert.strictEqual(backoff.computeBackoffDelay(NaN, 5000, 60000), 5000);
+        });
+    });
+
+});


### PR DESCRIPTION
Closes #20.

Implements all four requirements from the issue: show disconnected when there's no internet at startup, auto-login when it returns, re-enter the retry loop if the connection is later lost, and add debug log messages.

## Problem

The location node logged in exactly **once** in a fire-and-forget IIFE. If the internet was down at startup it emitted `initializeFailed` and **gave up forever**. The 30-minute refresh timer (`start()`) fired `refreshAccessToken()` with **no `.catch()` and no recovery path** — so a later connection loss left the node silently dead with a stale "connected" status, and once the ~1h refresh token expired there was no way back.

## Changes

- **Reconnect loop (location node):** `connect()` retries login with **exponential backoff (5s→60s, reset on success)** when the internet is unavailable at startup or the connection drops. Emits `connecting` / `connected` / `disconnected` and logs each attempt, success and failure.
- **Refresh-failure recovery (`ondusApi.js`):** `start(onError)` now catches scheduled refresh rejections and notifies the location node, which tears the session down and re-enters the loop. A fresh login obtains a new refresh token, so it recovers even after the old one expired.
- **Reconnect-safe sense node:** registers its `input` handler **once** and tracks connection state via `connected` / `disconnected` events instead of stacking a duplicate handler on every (re)initialization. Shows *disconnected* while offline and ignores input until reconnected.
- **Config vs connectivity errors:** a *location not found* (login worked, wrong name) no longer spins the retry loop and now lists the available locations.
- **`lib/backoff.js`:** small pure, unit-tested helper.

## Verification

`npm run lint` clean, `npm test` → 40 passing (4 new backoff tests). The reconnect/timer loop itself is network/timer bound and not unit-tested; the backoff math, locator and converters are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)