### PR TITLE
docs: remove GROHE Blue annotations from command docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.34.1] [2026-06-28]
+### removed the GROHE Blue annotations from the command documentation (README + inline help); this node targets Sense / Sense Guard (functional Blue notification texts are unchanged)
+
 ## [0.34.0] [2026-06-28]
 ### migrated to account-wide notifications (the per-appliance routes are no longer provided by the API): added getNotifications (paginated) / getAllNotifications / getNotification / markNotificationRead (PUT) / markNotificationsRead (PATCH) / deleteNotification / deleteNotifications, plus put/patch/del session helpers; the node now exposes msg.payload.notifications (true or { pageSize, continuationToken }), markRead, markAllRead, deleteNotification(s); the legacy getApplianceNotifications* are kept but re-implemented on top of the account-wide endpoint (filtered by appliance_id); added a notifications example flow and tests
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,6 @@ msg.payload = { command: { measure_now: true } };                               
 | `buzzer_on` | bool | Sense / Sense Guard. |
 | `buzzer_sound_profile` | int | Sense / Sense Guard. |
 | `get_current_measurement` | bool | Shared. |
-| `cleaning_mode` | bool | GROHE Blue. |
-| `co2_status_reset` | bool | GROHE Blue. |
-| `filter_status_reset` | bool | GROHE Blue. |
-| `temp_user_unlock_on` | bool | GROHE Blue. |
 | `reason_for_change` | int | Shared, optional metadata. |
 
 A wrong value type (e.g. `valve_open: "yes"`) is rejected with a `node.error` and nothing is sent. The underlying REST call:
@@ -199,7 +195,7 @@ GET …/appliances/{applianceId}/data/aggregated?from=2026-06-01&to=2026-06-28&g
 ```
 
 - **`groupBy`** buckets the data by `hour`, `day`, `week`, `month`, or `year`. The API expects these in **lower case**; the node accepts any casing on input and lower-cases it before the call. `hour` is the finest granularity — there is no minute-level option. An unrecognized value is rejected (logged) and falls back to `day`.
-- **`msg.payload.measurements`** — per-period readings. Fields (snake_case, as sent by the API): `date`, `timestamp`, `flowrate`, `pressure`, `temperature`, `temperature_guard`, `humidity`, `battery` (Blue/filter appliances may add `remaining_filter`, `remaining_co2`, `date_of_filter_replacement`, `date_of_co2_replacement`, `date_of_cleaning`). Absent fields are simply omitted by the appliance.
+- **`msg.payload.measurements`** — per-period readings. Fields (snake_case, as sent by the API): `date`, `timestamp`, `flowrate`, `pressure`, `temperature`, `temperature_guard`, `humidity`, `battery`. Absent fields are simply omitted by the appliance.
 - **`msg.payload.withdrawals`** — per-event water draws, in one of two shapes (detect by the keys present):
   - per-event draw: `{ starttime, stoptime, waterconsumption, maxflowrate }`
   - per-period cost summary: `{ date, waterconsumption, water_cost, energy_cost, hotwater_share }`

--- a/grohe/99-grohe.html
+++ b/grohe/99-grohe.html
@@ -144,7 +144,6 @@
                 <li><code>pressure_measurement_running</code> (bool)</li>
                 <li><code>buzzer_on</code> (bool), <code>buzzer_sound_profile</code> (int)</li>
                 <li><code>get_current_measurement</code> (bool)</li>
-                <li><code>cleaning_mode</code>, <code>co2_status_reset</code>, <code>filter_status_reset</code>, <code>temp_user_unlock_on</code> (bool, GROHE Blue)</li>
                 <li><code>reason_for_change</code> (int, optional metadata)</li>
             </ul>
             A wrong value type is rejected and nothing is sent.</dd>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-grohe-sense",
-    "version": "0.34.0",
+    "version": "0.34.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-grohe-sense",
-            "version": "0.34.0",
+            "version": "0.34.1",
             "license": "MIT",
             "dependencies": {
                 "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-grohe-sense",
-    "version": "0.34.0",
+    "version": "0.34.1",
     "description": "Grohe sense nodes via ondus API.",
     "node-red": {
         "version": ">=0.1.0",


### PR DESCRIPTION
This node targets Sense / Sense Guard, so the "GROHE Blue" labels in the command documentation are noise. Removes them from the README command field table and inline help, and drops the Blue/filter note in the aggregated measurements section. Functional Blue notification texts in the category/type mapping are unchanged. Version bumped to 0.34.1.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)