### PR TITLE
ci: gate the publish, add the standards check, drop --test-force-exit

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,3 +24,18 @@ jobs:
             - run: npm run format:check
             - run: npm test
             - run: npm run coverage:check
+            # Uploaded from one matrix leg only — the report is identical across them, and
+            # two legs writing the same artifact name is an error. Makes a coverage
+            # regression inspectable from the failing run instead of only reproducible locally.
+            - name: Upload coverage report
+              if: matrix.node-version == '22.x'
+              uses: actions/upload-artifact@v7
+              with:
+                  name: coverage-report
+                  # Only the readable report. `coverage/` also holds c8's raw V8 dump in
+                  # tmp/, which is ~97% of the bytes and inspectable by nothing — 23 MB of
+                  # tmp against a 647 kB report in the worst case here.
+                  path: |
+                      coverage/lcov-report
+                      coverage/lcov.info
+                  retention-days: 14

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,10 +2,31 @@ name: Publish to npm
 
 on:
     release:
+        # 'published' — not 'created', which also fires when a *draft* release is saved and
+        # would push unreleased code to npm.
         types: [published]
 
 jobs:
-    publish:
+    # The same gate as CI, re-run here on purpose. A release is cut from a tag, and nothing
+    # guarantees that tag points at a commit CI ever saw — so verify before publishing rather
+    # than assume. npm publish is irreversible: a version cannot be replaced once taken.
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
+              with:
+                  # This package declares engines >=20, so 20.x is its own baseline. The
+                  # template pins 22.x for repos that raised their floor above 20.
+                  node-version: 20.x
+            - run: npm ci
+            - run: npm run lint
+            - run: npm run format:check
+            - run: npm test
+
+    publish-npm:
+        # Without this the publish runs regardless of the checks above.
+        needs: build
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v7
@@ -14,7 +35,11 @@ jobs:
                   node-version: 20.x
                   registry-url: https://registry.npmjs.org
             - run: npm ci
-            - run: npm test
-            - run: npm publish
+            # A GitHub release flagged "pre-release" goes to the `beta` dist-tag, so users
+            # on Manage Palette — which tracks `latest` — are not auto-upgraded onto an
+            # unproven build. A plain `npm publish` would move `latest` to the beta and
+            # push it to every install; `latest` cannot be walked back to an earlier
+            # version by publishing, only by a separate dist-tag change.
+            - run: npm publish ${{ github.event.release.prerelease && '--tag beta' || '' }}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/standards-check.yml
+++ b/.github/workflows/standards-check.yml
@@ -1,0 +1,26 @@
+# Synced into target repos by `nrstd sync` as .github/workflows/standards-check.yml.
+# Fails CI if the repo drifts from the shared standard. Tool-neutral (no AI).
+# `nrstd audit` exits non-zero below 10/10, so a repo adopting this should run
+# `nrstd sync --write` first — otherwise its next push goes red on pre-existing drift.
+name: Standards check
+on:
+    push:
+        branches: [master, main]
+    pull_request:
+permissions:
+    contents: read
+jobs:
+    standards:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
+              with:
+                  node-version: 20.x
+            # Resolved from Git, not the npm registry: this package is deliberately
+            # unpublished (README "Install", option B), so a bare
+            # `npx --yes node-red-standards` fails every run with E404 before it can
+            # audit anything — which reads as drift when it is really a missing
+            # package. The repo is public, so no token is needed. If it is ever
+            # published, the short form becomes available and this can go back.
+            - run: npx --yes github:windkh/node-red-standards audit

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     ],
     "scripts": {
         "lint": "eslint .",
-        "test": "node --test --test-force-exit --test-timeout=30000 --test-concurrency=1",
+        "test": "node --test --test-timeout=30000 --test-concurrency=1",
         "lint:fix": "eslint . --fix",
         "format": "prettier --write .",
         "format:check": "prettier --check .",


### PR DESCRIPTION
Picks up the [node-red-standards 0.4.1](https://github.com/windkh/node-red-standards/commit/b0ab6cf) fixes.

### `npm-publish.yml` — the release had almost no gate

It was one job running `npm ci` → `npm test` → `npm publish`. No lint, no `format:check`, and no job separation, so nothing stood between a tag and an irreversible publish except the test suite. Now the standard's two-job shape: `build` runs lint, format:check and test, and `publish-npm` declares `needs: build`. A release is cut from a tag, and nothing guarantees that tag points at a commit CI ever saw.

It also used a plain `npm publish`, so a release flagged *pre-release* would have gone to `latest` and auto-upgraded every Manage Palette user onto an unproven build. `latest` cannot be walked back by publishing, only by a separate dist-tag change. Now routed to the `beta` dist-tag.

Node stays on **20.x**, not the template's 22.x — that pin exists for repos that raised their floor above the standard's `>=20` baseline (`node-red@5` requires `>=22.9`). This package declares `>=20`, so 20.x is its own baseline.

### `standards-check.yml` (new)

The weekly rollout has been trying to add this in #45, but its copy came from the broken template: `npx --yes node-red-standards audit` is the published-name form for a package that is deliberately unpublished, so it failed with `E404` on every run before it could audit anything. This copy resolves the CLI from Git.

`nrstd audit` reports **10/10** here, so the check goes green. **#45 is redundant once this lands.**

### `package.json`

Drops `--test-force-exit`. It calls `process.exit()` as soon as the last test finishes, racing libuv's teardown of keep-alive sockets and mock servers; on Windows that aborts the process *after* the results are in, so a whole file reports as failed while every test in it passed.

Verified locally first: **89 pass, exit 0, no hang.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)