### PR TITLE
chore: run node-red-standards from a local devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "eslint-config-prettier": "^10.1.8",
                 "globals": "^17.0.0",
                 "node-red-node-test-helper": "^0.3.4",
+                "node-red-standards": "github:windkh/node-red-standards",
                 "prettier": "^3.0.0"
             },
             "engines": {
@@ -1955,6 +1956,18 @@
             },
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/node-red-standards": {
+            "version": "0.5.0",
+            "resolved": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "nrstd": "bin/nrstd.mjs"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/object-inspect": {
@@ -4171,6 +4184,11 @@
                 "stoppable": "^1.1.0",
                 "supertest": "^7.1.4"
             }
+        },
+        "node-red-standards": {
+            "version": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "dev": true,
+            "from": "node-red-standards@github:windkh/node-red-standards"
         },
         "object-inspect": {
             "version": "1.13.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1959,8 +1959,8 @@
             }
         },
         "node_modules/node-red-standards": {
-            "version": "0.5.0",
-            "resolved": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "version": "0.5.1",
+            "resolved": "git+ssh://git@github.com/windkh/node-red-standards.git#f3982d0a9447df04a6074bf654aca39e174a5fc3",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4186,7 +4186,7 @@
             }
         },
         "node-red-standards": {
-            "version": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "version": "git+ssh://git@github.com/windkh/node-red-standards.git#f3982d0a9447df04a6074bf654aca39e174a5fc3",
             "dev": true,
             "from": "node-red-standards@github:windkh/node-red-standards"
         },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "coverage": "c8 npm test",
-        "coverage:check": "c8 --check-coverage npm test"
+        "coverage:check": "c8 --check-coverage npm test",
+        "standards:audit": "nrstd audit",
+        "standards:sync": "nrstd sync"
     },
     "keywords": [
         "node-red",
@@ -58,6 +60,7 @@
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.0.0",
         "node-red-node-test-helper": "^0.3.4",
+        "node-red-standards": "github:windkh/node-red-standards",
         "prettier": "^3.0.0"
     }
 }


### PR DESCRIPTION
### Why

`nrstd audit` was only reachable through `npx github:windkh/node-red-standards`, which refetches on every call and needs network. Declaring the standard as a devDependency makes `npm run standards:audit` work offline against the installed copy, and lets dependabot keep the reference moving — it already does this for the repos that had added it by hand.

The specifier is deliberately the moving `github:windkh/node-red-standards` and **not** a pinned commit. `node-red-contrib-ntrip` pinned a commit tarball and silently stopped receiving the standard for three releases while still reporting a clean audit against the frozen copy; `node-red-standards` 0.5.0 now treats any other specifier for itself as drift.

Worth knowing for the future: `npm install` does **not** re-resolve a git dependency whose existing lockfile entry already satisfies the specifier — only `npm update` or dependabot moves it. An unpinned specifier is therefore not by itself enough to keep a repo current. (`node-red-contrib-shelly` had an unpinned specifier and a lockfile stuck two releases back.)

### Contents

- `devDependencies["node-red-standards"] = "github:windkh/node-red-standards"`
- `scripts.standards:audit` / `scripts.standards:sync` — without these the devDependency is decoration
- lockfile pointing at 0.5.1

### Merge order

Touches the same `package-lock.json` as **#48** (`chore/refresh-lockfile`). Merge #48 first, then rebase this one — or the other way round, whichever suits; the second of the two needs a rebase either way.

Verified locally: lint, format:check, 89 tests. Audit 18/18.
