### PR TITLE
ci: declare least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,13 @@ on:
     pull_request:
         branches: [master, main]
 
+# Least privilege for GITHUB_TOKEN. Without an explicit block a workflow inherits the
+# repository default, which on many repos is read *and write* to everything -- flagged by
+# CodeQL as actions/missing-workflow-permissions. This job only reads the checkout; the
+# artifact upload authenticates with the runtime token, not GITHUB_TOKEN.
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -32,9 +39,12 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: coverage-report
-                  # Only the readable report. `coverage/` also holds c8's raw V8 dump in
-                  # tmp/, which is ~97% of the bytes and inspectable by nothing — 23 MB of
-                  # tmp against a 647 kB report in the worst case here.
+                  # Only the readable report, not all of `coverage/`. c8 also writes its
+                  # raw V8 dump to coverage/tmp, which is ~97% of the bytes and inspectable
+                  # by nothing — measured at 23 MB of tmp against a 647 kB report. Uploading
+                  # the directory ships that dead weight on every run for the whole
+                  # retention window, and the step exists to make a failure *readable*.
+                  # Requires c8 to emit a report: `"reporter": ["text", "lcov"]`.
                   path: |
                       coverage/lcov-report
                       coverage/lcov.info

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,12 @@ on:
             - 'v*'
             - 'V*'
 
+# Least privilege for GITHUB_TOKEN, declared at the top so it covers every job. The one job
+# that needs more (github-release, which creates the release) raises it to `contents: write`
+# for itself. npm authentication is a separate secret and is unaffected by this.
+permissions:
+    contents: read
+
 jobs:
     # The same gate as CI, re-run here on purpose, and on the same matrix. A release is cut from
     # a tag, and nothing guarantees that tag points at a commit CI ever saw -- a tag can be

--- a/.github/workflows/standards-check.yml
+++ b/.github/workflows/standards-check.yml
@@ -1,6 +1,6 @@
 # Synced into target repos by `nrstd sync` as .github/workflows/standards-check.yml.
 # Fails CI if the repo drifts from the shared standard. Tool-neutral (no AI).
-# `nrstd audit` exits non-zero below 10/10, so a repo adopting this should run
+# `nrstd audit` exits non-zero on any gap, so a repo adopting this should run
 # `nrstd sync --write` first — otherwise its next push goes red on pre-existing drift.
 name: Standards check
 on:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,18 @@
 'use strict';
-// Flat ESLint config — standard for windkh node-red node repos (ESLint >= 9).
+// Flat ESLint config — standard for windkh node-red node repos (ESLint >= 10).
+// Verified unchanged against the full v10 stack: eslint@10, @eslint/js@10,
+// eslint-config-prettier@10, globals@17.
 const js = require('@eslint/js');
 const globals = require('globals');
 const prettier = require('eslint-config-prettier');
 
 module.exports = [
+    {
+        // c8 writes coverage/ on every `npm run coverage`, and linting generated output is
+        // noise at best. A repo adds its own ignores here (vendored code, device scripts that
+        // do not run on Node); keep those in the same block rather than a second one.
+        ignores: ['coverage/**'],
+    },
     js.configs.recommended,
     {
         languageOptions: {


### PR DESCRIPTION
Closes the three open CodeQL alerts, all `actions/missing-workflow-permissions` (medium):

| Alert | File | Job |
|---|---|---|
| #6 | `node.js.yml:11` | `build` |
| #8 | `npm-publish.yml:30` | `verify` |
| #7 | `npm-publish.yml:60` | `publish-npm` |

### Why this is not cosmetic

The repository default is `write` — checked via the API, not assumed:

```
default_workflow_permissions = "write"
can_approve_pull_request_reviews = true
```

Without an explicit block those jobs ran with a `GITHUB_TOKEN` holding write access to the repo. That matters most in `npm-publish.yml`, which is tag-triggered, publishes without a second confirmation, and holds the npm token.

None of the three needs write: `checkout` reads, `upload-artifact` authenticates with the Actions runtime token rather than `GITHUB_TOKEN`, and `npm publish` uses `NODE_AUTH_TOKEN` — a separate secret that `permissions` does not affect. The one job that does need write, `github-release`, already declared `contents: write` and keeps it; the new top-level block is a default, not a ceiling.

### Not hand-written

The standard's templates already carried these blocks — the copies here were stale. All three workflow files were taken from the templates wholesale, after diffing to confirm there was no local customisation to lose (`standards-check.yml` differed only in one comment line).

`nrstd sync` alone would not have fixed it: it reports the workflows as `differs (kept; use --force)`, and `--force` was the wrong tool because it would also overwrite `.claude/settings.json` (10 grown allowlist entries vs 3 in the template).

### About the eslint.config.js change

Same template refresh; it adds `ignores: ['coverage/**']`. Being precise about its value: **it is not load-bearing here.** `eslint .` already skips `coverage/` because `.gitignore` lists it and ESLint 10 honours `.gitignore` — verified by linting with and without the rule, both exit 0, while a `var`-using file in a non-ignored directory does error. Kept as a safety net and to stay identical to the template.

### Verified

With `coverage/` present on disk: lint, format:check, test (89/89), coverage:check all exit 0; standards audit 18/18.